### PR TITLE
Oprava nefunkčního seznamu pořadů

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,5 @@
+2019-05-01
+ * Oprava seznamu poradu
 2019-03-14
  * Zmena na webu Nova Plus (odkaz na porad vede rovnou na nejnovejsi dil)
 2019-01-16

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.dmd-czech.novaplus"
        name="Nova Plus TV Archiv"
-       version="1.0.16"
+       version="1.0.17"
        provider-name="Jiri Vyhnalek">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/default.py
+++ b/default.py
@@ -93,20 +93,13 @@ def CATEGORIES(url,page):
     doc = read_page(url)
 
     for article in doc.findAll('article'):
-        url = article.a['href'].encode('utf-8')
-        title = article.a['title'].encode('utf-8')
-        thumb = article.a.div.img['data-original'].encode('utf-8')
-        addDir(title,url,2,thumb,1)
+        url, title, thumb = None, None, None
 
-#def EPISODES(url,page):
-#    print 'EPISODES *********************************' + str(url)
-#    doc = read_page(url)
-#
-#    for article in doc.findAll('article', 'b-article b-article-no-labels'):
-#        url = article.a['href'].encode('utf-8')
-#        title = article.a['title'].encode('utf-8')
-#        thumb = article.a.div.img['data-original'].encode('utf-8')
-#        addDir(title,url,3,thumb,1)
+        if article.a is not None:
+          url = article.a['href'].encode('utf-8')
+          title = article.a['title'].encode('utf-8')
+          thumb = article.a.div.img['data-original'].encode('utf-8')
+          addDir(title,url,2,thumb,1)
 
 def VIDEOLINK(url,name):
     print 'VIDEOLINK *********************************' + str(url)


### PR DESCRIPTION
Nefunkční seznam pořadů po změně stránek (nově se může vyskytovat "falešný" tag `<article>` - písmeno - bez odkazu na pořad). 